### PR TITLE
Fix weekly pregnancy emails: CAS claim silently failing since June 1

### DIFF
--- a/.github/workflows/scheduled-emails.yml
+++ b/.github/workflows/scheduled-emails.yml
@@ -52,6 +52,14 @@ jobs:
             echo "Response: $body"
 
             if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 400 ]; then
+              # HTTP 200 alone is not success — the function returns 200 even
+              # when every per-user send fails (June–July 2026 outage). Fail
+              # loudly if any per-user error occurred.
+              errors=$(echo "$body" | jq -r '.errors // 0' 2>/dev/null || echo 0)
+              if [ "$errors" -gt 0 ]; then
+                echo "::error::Weekly emails ran but $errors user(s) failed — check the response above"
+                exit 1
+              fi
               echo "Weekly emails succeeded."
               exit 0
             fi

--- a/nesty-web/supabase/functions/send-weekly-emails/index.ts
+++ b/nesty-web/supabase/functions/send-weekly-emails/index.ts
@@ -1339,14 +1339,21 @@ serve(async (req) => {
         // .or() matches when previous value is NULL OR less than currentWeek
         // (we never want to send backwards). targetUserId path skips the
         // claim — manual/test runs should always send.
+        //
+        // IMPORTANT: use count:'exact' and NO .select() here. PostgREST
+        // re-applies the .or() filter to the RETURNING projection of an
+        // UPDATE: with .select('id') the filter column isn't in the
+        // projection → 42703 "column does not exist" (this silently killed
+        // ALL weekly emails from 2026-06-01 to 2026-07-14). And even with
+        // the column selected, the outer filter evaluates on POST-update
+        // values (always false after a claim) → claimed rows come back
+        // empty. Row count sidesteps both.
         if (!targetUserId) {
-          const { data: claimed, error: claimErr } = await supabaseAdmin
+          const { count: claimedCount, error: claimErr } = await supabaseAdmin
             .from('profiles')
-            .update({ last_weekly_email_week: currentWeek })
+            .update({ last_weekly_email_week: currentWeek }, { count: 'exact' })
             .eq('id', profile.id)
             .or(`last_weekly_email_week.is.null,last_weekly_email_week.lt.${currentWeek}`)
-            .select('id')
-            .maybeSingle()
 
           if (claimErr) {
             console.error(`Claim error for ${profile.email}:`, claimErr)
@@ -1354,7 +1361,7 @@ serve(async (req) => {
             continue
           }
 
-          if (!claimed) {
+          if (!claimedCount) {
             // Another concurrent invocation already claimed (and is sending)
             // this week's email. Safe to skip.
             results.push({ email: profile.email, week: currentWeek, status: 'already_claimed' })
@@ -1446,9 +1453,13 @@ serve(async (req) => {
     }
 
     const sentCount = results.filter(r => r.status === 'sent').length
+    // Surface per-user failures at the top level so the GitHub Actions
+    // caller can fail the run — an HTTP 200 with sent:0 and 297 claim
+    // errors masqueraded as success for 6 weeks.
+    const errorCount = results.filter(r => r.status.includes('error')).length
 
     return new Response(
-      JSON.stringify({ success: true, sent: sentCount, total: profiles.length, results }),
+      JSON.stringify({ success: true, sent: sentCount, errors: errorCount, total: profiles.length, results }),
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 }
     )
   } catch (error) {


### PR DESCRIPTION
## What broke

The atomic-claim UPDATE added on 2026-05-31 (`4808b17`, to stop duplicate weekly sends) combined `.or()` with `.select('id')`. PostgREST re-applies the `or` filter to the RETURNING projection of an UPDATE — where the filter column isn't selected — producing `42703: column profiles.last_weekly_email_week does not exist` for **every user on every run**, while the function still returned HTTP 200 with `sent: 0`.

**Result: zero weekly pregnancy/postpartum emails were sent from 2026-06-01 to 2026-07-14.** 297 eligible users were affected (143 of them signed up during the outage and never received a single weekly email).

## The fix

- Claim uses `count: 'exact'` with no `.select()` — the affected-row count says whether we won the claim; no RETURNING projection means no outer re-filter. (Verified against production PostgREST via curl + `pg_stat_statements`.)
- The naive workaround of adding the column to `.select()` would have been worse: the outer filter evaluates on *post-update* values, so every claim would return empty → 'already_claimed' → never send.
- Function response now includes a top-level `errors` count.
- The GitHub Actions workflow fails the run when `errors > 0` instead of trusting HTTP 200 — this outage was invisible because every run was green.

## Deployment status

The fixed function is already deployed to production as **v21** and smoke-tested. This PR tracks the source + the workflow guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)